### PR TITLE
Fixed data loading code for SRX: step scan data failed to load if the scan is incomplete

### DIFF
--- a/pyxrf/gui_module/main_window.py
+++ b/pyxrf/gui_module/main_window.py
@@ -581,7 +581,7 @@ class DialogAbout(QDialog):
             "Brookhaven National Laboratory"
         )
 
-        text_copyright = f"\u00A92015\u2014{datetime.now().year} Brookhaven National Laboratory"
+        text_copyright = f"\u00a92015\u2014{datetime.now().year} Brookhaven National Laboratory"
 
         label_name = QLabel(text_name)
         label_name.setStyleSheet("QLabel {font-weight: bold; font-size: 32px}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed the issue with loading raw data collected at SRX. If a step scan is interrupted in the row, the collected data needs to be padded with extra data points (zeros) to fill the last scanned row. The changes in this PR implement this procedure.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Data loading function for SRX beamline. Fixed the issue that prevented loading of incomplete step scans.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The modified PyXRF were manually tested at the beamline on the following: scan IDs 163746 (interrupted step scan) and 163747 (complete step scan).

<!--
## Screenshots (if appropriate):
-->
